### PR TITLE
Remove warning for Terraform 0.12 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
-        args: ['--args=--sort-by-required']
+        args: ['--args=--sort-by required']
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # BIG-IP Declarative Onboarding builder sub-module
 
-> You are viewing a **2.x release** of the modules, which supports
-> **Terraform 0.13** only. *For modules compatible with Terraform 0.12, use a
-> 1.x release.* Functionality is identical, but separate releases are required
-> due to the difference in *variable validation* between Terraform 0.12 and 0.13.
-
 This module encapsulates the creation of a set of DO payloads that support a very
 basic configuration of BIG-IP at run-time. It is **NOT** a substitute for a custom
 DO payload.


### PR DESCRIPTION
This was carried over from original module [source](https://github.com/memes/terraform-google-f5-bigip) modules which have legacy support for Terraform 0.12. This standalone module has a constraint on Terraform 0.13+.